### PR TITLE
Add codeowners-validator-vibe workflow

### DIFF
--- a/.github/workflows/codeowners-validator-vibe.yml
+++ b/.github/workflows/codeowners-validator-vibe.yml
@@ -1,0 +1,38 @@
+name: "Codeowners Validator (Vibe)"
+
+# Vibe-coded repos created from myhelix/vibe-applications-amplify-template
+# scope CODEOWNERS to ET-protected paths only — currently:
+#   amplify/helix-tags.ts
+#   amplify.yml
+#   /.github/workflows/
+#   /.github/CODEOWNERS
+# The rest of the tree is intentionally unowned so vibe coders aren't gated
+# by a team review on every PR. The standard codeowners-validator runs the
+# experimental `notowned` check and warns on every uncovered file, exiting
+# non-zero.
+#
+# This variant drops `notowned`. files / owners / duppatterns / syntax
+# still run, so real CODEOWNERS bugs (typos, stale teams, dup patterns,
+# bad syntax) are still caught.
+
+on:
+  workflow_call:
+    secrets:
+      owners-validator-github-secret:
+        description: 'GitHub PAT to check that owner definitions are valid'
+        required: true
+
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: GitHub CODEOWNERS Validator
+        uses: mszostok/codeowners-validator@v0.7.1
+        with:
+          checks: "files,owners,duppatterns,syntax"
+          # experimental_checks intentionally omitted — see header.
+          github_access_token: "${{ secrets.owners-validator-github-secret }}"
+          repository_path: "."
+          check_failure_level: "warning"
+          owner_checker_repository: "${{ github.repository }}"

--- a/.github/workflows/codeowners-validator-vibe.yml
+++ b/.github/workflows/codeowners-validator-vibe.yml
@@ -16,7 +16,7 @@ jobs:
   sanity:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Uncomment global '* @<org>/<slug>' catch-all
         run: |

--- a/.github/workflows/codeowners-validator-vibe.yml
+++ b/.github/workflows/codeowners-validator-vibe.yml
@@ -1,19 +1,9 @@
 name: "Codeowners Validator (Vibe)"
 
-# Vibe-coded repos created from myhelix/vibe-applications-amplify-template
-# scope CODEOWNERS to ET-protected paths only — currently:
-#   amplify/helix-tags.ts
-#   amplify.yml
-#   /.github/workflows/
-#   /.github/CODEOWNERS
-# The rest of the tree is intentionally unowned so vibe coders aren't gated
-# by a team review on every PR. The standard codeowners-validator runs the
-# experimental `notowned` check and warns on every uncovered file, exiting
-# non-zero.
-#
-# This variant drops `notowned`. files / owners / duppatterns / syntax
-# still run, so real CODEOWNERS bugs (typos, stale teams, dup patterns,
-# bad syntax) are still caught.
+# Same checks as the standard variant. Vibe repos ship CODEOWNERS with a
+# commented catch-all `# * @<org>/<slug>` so PR reviews stay scoped to
+# explicit per-path rules. We uncomment it in the CI checkout so notowned
+# sees full coverage. Fails if the catch-all is missing entirely.
 
 on:
   workflow_call:
@@ -27,11 +17,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Uncomment global '* @<org>/<slug>' catch-all
+        run: |
+          codeowners=".github/CODEOWNERS"
+          if [ ! -f "$codeowners" ]; then
+            echo "::error file=$codeowners::CODEOWNERS file is missing"
+            exit 1
+          fi
+          if ! grep -qE '^#?[[:space:]]*\*[[:space:]]+@[^/[:space:]]+/[A-Za-z0-9._-]+' "$codeowners"; then
+            echo "::error file=$codeowners::Missing global catch-all '* @<org>/<slug>' (commented or uncommented)."
+            exit 1
+          fi
+          sed -i 's/^#[[:space:]]*\(\*[[:space:]]\+@\)/\1/' "$codeowners"
+
       - name: GitHub CODEOWNERS Validator
         uses: mszostok/codeowners-validator@v0.7.1
         with:
           checks: "files,owners,duppatterns,syntax"
-          # experimental_checks intentionally omitted — see header.
+          experimental_checks: "notowned"
           github_access_token: "${{ secrets.owners-validator-github-secret }}"
           repository_path: "."
           check_failure_level: "warning"

--- a/.github/workflows/codeowners-validator-vibe.yml
+++ b/.github/workflows/codeowners-validator-vibe.yml
@@ -16,7 +16,7 @@ jobs:
   sanity:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Uncomment global '* @<org>/<slug>' catch-all
         run: |


### PR DESCRIPTION
## Summary

Adds a vibe-tuned variant of \`codeowners-validator.yml\` for repos created from \`myhelix/vibe-applications-amplify-template\`.

These repos scope \`CODEOWNERS\` to ET-protected paths only:
- \`amplify/**/helix-*\`
- \`amplify/auth/resource.ts\`
- \`src/helix-*\`
- \`amplify.yml\`
- \`/.github/workflows/\`
- \`/.github/CODEOWNERS\`
- \`/.helix-template.yml\`

The rest of the tree is intentionally unowned on disk so vibe coders aren't gated by team review on every PR. To keep \`notowned\` semantics intact in CI, the template ships \`CODEOWNERS\` with a commented global catch-all of the form \`# * @<org>/<slug>\`.

## Diff vs the standard variant

- **Adds a pre-processing step** that uncomments \`# * @<org>/<slug>\` in the CI checkout (in-place, never pushed) so the validator sees full path coverage. If the line is already uncommented, the sed is a no-op.
- **Fails if the catch-all line is missing entirely** (commented or uncommented), which is the vibe substitute for the standard \`notowned\` signal that a global owner exists.
- Same \`files / owners / duppatterns / syntax / notowned\` checks as the standard variant — no checks dropped.

## After merge

Tag a \`v1.1.0\` so the template wrapper can pin to it.

## Test plan

- [ ] Tag \`v1.1.0\` after merge
- [ ] Update pin in [vibe-applications-amplify-template#66](https://github.com/myhelix/vibe-applications-amplify-template/pull/66) from \`@main\` → \`@v1.1.0\` and merge
- [ ] Verify a vibe repo (e.g. \`irina-test-14\`) goes green
- [ ] Verify a vibe repo with the \`# * @<org>/<slug>\` line removed goes red
- [ ] Verify a vibe repo with the line already uncommented still goes green (idempotent sed)